### PR TITLE
Set sql_types macro so that diesel doesn't complain about Insertable derives

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "diesel-citext"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Greg Elenbaas <me@gregelenbaas.com>"]
 edition = "2018"
 readme = "README.md"

--- a/src/sql_types.rs
+++ b/src/sql_types.rs
@@ -1,3 +1,3 @@
-#[derive(SqlType)]
+#[derive(QueryId, SqlType)]
 #[postgres(type_name = "citext")]
 pub struct Citext;

--- a/src/types.rs
+++ b/src/types.rs
@@ -19,6 +19,7 @@ use actix_web::dev::FromParam;
 /// a hashmap as well as be written to the page. It implements a variety of traits
 /// to make it easy to convert from and to &str and String types.
 #[derive(Clone, Debug, Serialize, Deserialize, FromSqlRow, AsExpression)]
+#[sql_type = "Citext"]
 pub struct CiString {
     value: String,
 }


### PR DESCRIPTION
Yo! Seems like a simple oversight, so figured I'd pull request. Using this in a script and noticed `diesel` complains when I wanna make a struct `Insertable` that has a `CiString`. Glancing over `diesel-geography` it seemed like this was the only difference, and made things work for my case.

Def lemme know if I'm incorrect though!