### PR TITLE
deserialize CiString as plain type

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,10 +1,13 @@
 # CHANGE Log
 
+## 0.4.0
+
+* Serialize and Deserialize CiString as plain type
+
 ## 0.3.0
 
 * Add Partial Eq Support
 * Set SQL Types Macro to fix error message for Insertable Derives
-
 
 ## 0.2.0
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "diesel-citext"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["Greg Elenbaas <me@gregelenbaas.com>"]
 edition = "2018"
 readme = "README.md"
@@ -12,11 +12,9 @@ keywords = ["database", "sql", "orm", "citext", "diesel"]
 categories = ["database"]
 
 [features]
-
 with-actix-web = ["actix-web"]
 
 [dependencies]
 actix-web = { version = "0.7", optional = true }
 diesel = { version = "1.3", features = ["postgres"] }
 serde = { version = "1.0", features = ["derive"]}
-

--- a/src/types.rs
+++ b/src/types.rs
@@ -15,15 +15,15 @@ use crate::sql_types::*;
 #[cfg(feature = "with-actix-web")]
 use actix_web::dev::FromParam;
 
-/// `CiString` is a CaseInsenstive String type that can be used as the key for
+/// `CiString` is a CaseInsensitive String type that can be used as the key for
 /// a hashmap as well as be written to the page. It implements a variety of traits
 /// to make it easy to convert from and to &str and String types.
 #[derive(Clone, Debug, Serialize, Deserialize, FromSqlRow, AsExpression)]
+#[serde(transparent)]
 #[sql_type = "Citext"]
 pub struct CiString {
     value: String,
 }
-
 
 impl CiString {
     pub fn new() -> Self {
@@ -34,7 +34,7 @@ impl CiString {
 }
 
 /// CiString can implement the FromParam trait from ActixWeb if "with-actix-web" is
-/// turned on in the Cargo.toml file. 
+/// turned on in the Cargo.toml file.
 #[cfg(feature = "with-actix-web")]
 impl FromParam for CiString {
     type Err = actix_web::error::UrlParseError;


### PR DESCRIPTION
As in the title, adding `#[serde(transparent)]` would allow to `Serialize` and `Deserialize` `CiString` as it was a `String` type.

```rust
let j = json!("Foo");
let s: CiString = serde_json::from_value(j);
```
