### PR TITLE
Change behaviour to preserve the original string

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,8 +2,10 @@
 
 ## 0.4.0
 
+* Bug fix on CiString deserialize (now the string is lower case as expected)
 * Serialize and Deserialize CiString as plain type
 * FromStr for CiString now returns Result<CiString, ()> instead of Result<CiString, fmt::Error>
+* Add Default trait impl for CiString
 
 ## 0.3.0
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@
 ## 0.4.0
 
 * Serialize and Deserialize CiString as plain type
+* FromStr for CiString now returns Result<CiString, ()> instead of Result<CiString, fmt::Error>
 
 ## 0.3.0
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,3 +18,6 @@ with-actix-web = ["actix-web"]
 actix-web = { version = "0.7", optional = true }
 diesel = { version = "1.3", features = ["postgres"] }
 serde = { version = "1.0", features = ["derive"]}
+
+[dev-dependencies]
+serde_json = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ with-actix-web = ["actix-web"]
 [dependencies]
 actix-web = { version = "0.7", optional = true }
 diesel = { version = "^1.3", features = ["postgres"] }
-serde = { version = "1.0", features = ["derive"]}
+serde = { version = "1.0", features = ["derive"] }
 
 [dev-dependencies]
 serde_json = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ with-actix-web = ["actix-web"]
 
 [dependencies]
 actix-web = { version = "0.7", optional = true }
-diesel = { version = "1.3", features = ["postgres"] }
+diesel = { version = "^1.3", features = ["postgres"] }
 serde = { version = "1.0", features = ["derive"]}
 
 [dev-dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,8 @@
 //! Diesel support for Postgres citext Extension
 
 #![allow(proc_macro_derive_resolution_fallback)]
-#[macro_use] extern crate diesel;
+#[macro_use]
+extern crate diesel;
 
 extern crate serde;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,5 +9,11 @@ extern crate serde;
 #[cfg(feature = "with-actix-web")]
 extern crate actix_web;
 
+#[cfg(test)]
+extern crate serde_json;
+
 pub mod sql_types;
 pub mod types;
+
+#[cfg(test)]
+mod tests;

--- a/src/sql_types.rs
+++ b/src/sql_types.rs
@@ -1,3 +1,3 @@
-#[derive(QueryId, SqlType)]
+#[derive(Debug, Clone, Copy, QueryId, SqlType)]
 #[postgres(type_name = "citext")]
 pub struct Citext;

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,0 +1,18 @@
+use crate::types::CiString;
+use serde_json::json;
+
+const SEED: &str = "CaFeBaBe";
+const UPPER: &str = "CAFEBABE";
+const LOWER: &str = "cafebabe";
+const INVERTED: &str = "cAfEbAbE";
+
+#[test]
+fn it_works() {
+    let v = json!(SEED);
+    let s: CiString = serde_json::from_value(v).unwrap();
+
+    assert_eq!(s, SEED);
+    assert_eq!(s, UPPER);
+    assert_eq!(s, LOWER);
+    assert_eq!(s, INVERTED);
+}

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -23,9 +23,6 @@ fn test_eq(sut: CiString) {
     assert_eq!(sut, CiString::from(UPPER));
     assert_eq!(sut, CiString::from(LOWER));
     assert_eq!(sut, CiString::from(INVERTED));
-
-    let s: String = sut.into();
-    assert_eq!(s, LOWER);
 }
 
 #[test]
@@ -44,4 +41,19 @@ fn test_from_string() {
 fn test_deserialization() {
     let sut = serde_json::from_value::<CiString>(json!(SEED)).unwrap();
     test_eq(sut)
+}
+
+#[test]
+fn test_roundtrip() {
+    let original = String::from(SEED);
+    let ci = CiString::from(SEED);
+    let roundtripped: String = ci.into();
+
+    assert_eq!(original, roundtripped);
+}
+
+#[test]
+fn test_format_keeps_capitalization() {
+    let fmt = format!("{}", CiString::from(SEED));
+    assert_eq!(fmt, SEED);
 }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -23,6 +23,9 @@ fn test_eq(sut: CiString) {
     assert_eq!(sut, CiString::from(UPPER));
     assert_eq!(sut, CiString::from(LOWER));
     assert_eq!(sut, CiString::from(INVERTED));
+
+    let s: String = sut.into();
+    assert_eq!(s, String::from(SEED));
 }
 
 #[test]
@@ -40,7 +43,7 @@ fn test_from_string() {
 #[test]
 fn test_deserialization() {
     let sut = serde_json::from_value::<CiString>(json!(SEED)).unwrap();
-    test_eq(sut)
+    test_eq(sut);
 }
 
 #[test]

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -6,13 +6,42 @@ const UPPER: &str = "CAFEBABE";
 const LOWER: &str = "cafebabe";
 const INVERTED: &str = "cAfEbAbE";
 
-#[test]
-fn it_works() {
-    let v = json!(SEED);
-    let s: CiString = serde_json::from_value(v).unwrap();
+fn test_eq(sut: CiString) {
+    assert_eq!(sut, sut);
 
-    assert_eq!(s, SEED);
-    assert_eq!(s, UPPER);
+    assert_eq!(sut, SEED);
+    assert_eq!(sut, UPPER);
+    assert_eq!(sut, LOWER);
+    assert_eq!(sut, INVERTED);
+
+    assert_eq!(sut, String::from(SEED));
+    assert_eq!(sut, String::from(UPPER));
+    assert_eq!(sut, String::from(LOWER));
+    assert_eq!(sut, String::from(INVERTED));
+
+    assert_eq!(sut, CiString::from(SEED));
+    assert_eq!(sut, CiString::from(UPPER));
+    assert_eq!(sut, CiString::from(LOWER));
+    assert_eq!(sut, CiString::from(INVERTED));
+
+    let s: String = sut.into();
     assert_eq!(s, LOWER);
-    assert_eq!(s, INVERTED);
+}
+
+#[test]
+fn test_from_str() {
+    let sut = CiString::from(SEED);
+    test_eq(sut);
+}
+
+#[test]
+fn test_from_string() {
+    let sut = CiString::from(SEED.to_string());
+    test_eq(sut);
+}
+
+#[test]
+fn test_deserialization() {
+    let sut = serde_json::from_value::<CiString>(json!(SEED)).unwrap();
+    test_eq(sut)
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -18,7 +18,7 @@ use actix_web::dev::FromParam;
 /// `CiString` is a CaseInsensitive String type that can be used as the key for
 /// a hashmap as well as be written to the page. It implements a variety of traits
 /// to make it easy to convert from and to &str and String types.
-#[derive(Clone, Debug, Serialize, Deserialize, FromSqlRow, AsExpression)]
+#[derive(AsExpression, Clone, Debug, Default, Deserialize, FromSqlRow, Serialize)]
 #[serde(transparent)]
 #[sql_type = "Citext"]
 pub struct CiString {

--- a/src/types.rs
+++ b/src/types.rs
@@ -20,9 +20,7 @@ use actix_web::dev::FromParam;
 #[derive(AsExpression, Clone, Debug, Default, Deserialize, FromSqlRow, Serialize)]
 #[serde(transparent)]
 #[sql_type = "Citext"]
-pub struct CiString {
-    value: String,
-}
+pub struct CiString(String);
 
 impl CiString {
     pub fn new() -> Self {
@@ -43,25 +41,25 @@ impl FromParam for CiString {
 
 impl fmt::Display for CiString {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.value)
+        write!(f, "{}", self.0)
     }
 }
 
 impl PartialEq for CiString {
     fn eq(&self, other: &CiString) -> bool {
-        self.value.to_lowercase() == other.value.to_lowercase()
+        self.0.to_lowercase() == other.0.to_lowercase()
     }
 }
 
 impl PartialEq<String> for CiString {
     fn eq(&self, other: &String) -> bool {
-        self.value.to_lowercase() == other.to_lowercase()
+        self.0.to_lowercase() == other.to_lowercase()
     }
 }
 
 impl PartialEq<&str> for CiString {
     fn eq(&self, other: &&str) -> bool {
-        self.value.to_lowercase() == other.to_lowercase()
+        self.0.to_lowercase() == other.to_lowercase()
     }
 }
 
@@ -69,19 +67,19 @@ impl Eq for CiString {}
 
 impl Hash for CiString {
     fn hash<H: Hasher>(&self, hasher: &mut H) {
-        self.value.to_lowercase().hash(hasher);
+        self.0.to_lowercase().hash(hasher);
     }
 }
 
 impl AsRef<str> for CiString {
     fn as_ref(&self) -> &str {
-        self.value.as_ref()
+        self.0.as_ref()
     }
 }
 
 impl Borrow<str> for CiString {
     fn borrow(&self) -> &str {
-        self.value.borrow()
+        self.0.borrow()
     }
 }
 
@@ -89,7 +87,7 @@ impl Deref for CiString {
     type Target = String;
 
     fn deref(&self) -> &Self::Target {
-        &self.value
+        &self.0
     }
 }
 
@@ -103,21 +101,19 @@ impl FromStr for CiString {
 
 impl Into<String> for CiString {
     fn into(self) -> String {
-        self.value
+        self.0
     }
 }
 
 impl From<String> for CiString {
     fn from(value: String) ->  Self {
-        CiString { value }
+        CiString(value)
     }
 }
 
 impl From<&str> for CiString {
     fn from(value: &str) ->  Self {
-        CiString {
-            value: value.into(),
-        }
+        CiString(value.into())
     }
 }
 
@@ -131,7 +127,7 @@ impl FromSql<Citext, Pg> for CiString {
 
 impl ToSql<Citext, Pg> for CiString {
     fn to_sql<W: Write>(&self, out: &mut Output<W, Pg>) -> serialize::Result {
-        Ok(out.write_all(self.value.as_bytes())
+        Ok(out.write_all(self.0.as_bytes())
             .map(|_| IsNull::No)?)
     }
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -97,7 +97,7 @@ impl Borrow<str> for CiString {
 impl Deref for CiString {
     type Target = String;
 
-    fn deref(&self) -> &String {
+    fn deref(&self) -> &Self::Target {
         &self.value
     }
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -19,7 +19,9 @@ use actix_web::dev::FromParam;
 /// `CiString` is a CaseInsensitive String type that can be used as the key for
 /// a hashmap as well as be written to the page. It implements a variety of traits
 /// to make it easy to convert from and to &str and String types.
-#[derive(AsExpression, Clone, Debug, Default, Deserialize, FromSqlRow, Serialize, PartialOrd)]
+#[derive(Clone, Debug, Default, PartialOrd, Ord, Eq)]
+#[derive(Deserialize, Serialize)]
+#[derive(AsExpression, FromSqlRow)]
 #[serde(transparent)]
 #[sql_type = "Citext"]
 pub struct CiString(String);
@@ -64,8 +66,6 @@ impl PartialEq<&str> for CiString {
         self.0.to_lowercase() == other.to_lowercase()
     }
 }
-
-impl Eq for CiString {}
 
 impl Hash for CiString {
     fn hash<H: Hasher>(&self, hasher: &mut H) {

--- a/src/types.rs
+++ b/src/types.rs
@@ -2,7 +2,7 @@ use crate::sql_types::*;
 use diesel::deserialize::{self, FromSql};
 use diesel::pg::Pg;
 use diesel::serialize::{self, IsNull, Output, ToSql};
-use serde::{Deserialize, Deserializer, Serialize};
+use serde::{Deserialize, Serialize};
 use std::borrow::Borrow;
 use std::cmp::{Eq, PartialEq};
 use std::fmt;
@@ -14,13 +14,6 @@ use std::str::FromStr;
 #[cfg(feature = "with-actix-web")]
 use actix_web::dev::FromParam;
 
-fn de_case_insensitive<'de, D>(deserializer: D) -> Result<String, D::Error>
-where
-    D: Deserializer<'de>,
-{
-    Ok(String::deserialize(deserializer)?.to_lowercase())
-}
-
 /// `CiString` is a CaseInsensitive String type that can be used as the key for
 /// a hashmap as well as be written to the page. It implements a variety of traits
 /// to make it easy to convert from and to &str and String types.
@@ -28,7 +21,6 @@ where
 #[serde(transparent)]
 #[sql_type = "Citext"]
 pub struct CiString {
-    #[serde(deserialize_with = "de_case_insensitive")]
     value: String,
 }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -19,7 +19,7 @@ use actix_web::dev::FromParam;
 /// `CiString` is a CaseInsensitive String type that can be used as the key for
 /// a hashmap as well as be written to the page. It implements a variety of traits
 /// to make it easy to convert from and to &str and String types.
-#[derive(AsExpression, Clone, Debug, Default, Deserialize, FromSqlRow, Serialize)]
+#[derive(AsExpression, Clone, Debug, Default, Deserialize, FromSqlRow, Serialize, PartialOrd)]
 #[serde(transparent)]
 #[sql_type = "Citext"]
 pub struct CiString(String);

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,7 +1,7 @@
 use crate::sql_types::*;
 use diesel::deserialize::{self, FromSql};
 use diesel::pg::Pg;
-use diesel::serialize::{self, IsNull, Output, ToSql};
+use diesel::serialize::{self, Output, ToSql};
 use diesel::sql_types::Text;
 use diesel::backend::Backend;
 use serde::{Deserialize, Serialize};

--- a/src/types.rs
+++ b/src/types.rs
@@ -84,13 +84,13 @@ impl Hash for CiString {
 
 impl AsRef<str> for CiString {
     fn as_ref(&self) -> &str {
-        &*self.value
+        self.value.as_ref()
     }
 }
 
 impl Borrow<str> for CiString {
     fn borrow(&self) -> &str {
-        &*self.value
+        self.value.borrow()
     }
 }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,3 +1,8 @@
+use crate::sql_types::*;
+use diesel::deserialize::{self, FromSql};
+use diesel::pg::Pg;
+use diesel::serialize::{self, IsNull, Output, ToSql};
+use serde::{Deserialize, Serialize};
 use std::borrow::Borrow;
 use std::cmp::{Eq, PartialEq};
 use std::error::Error;
@@ -6,11 +11,6 @@ use std::hash::{Hash, Hasher};
 use std::io::prelude::*;
 use std::ops::Deref;
 use std::str::FromStr;
-use diesel::deserialize::{self, FromSql};
-use diesel::serialize::{self, IsNull, Output, ToSql};
-use diesel::pg::Pg;
-use serde::{Serialize, Deserialize};
-use crate::sql_types::*;
 
 #[cfg(feature = "with-actix-web")]
 use actix_web::dev::FromParam;
@@ -40,7 +40,7 @@ impl FromParam for CiString {
     type Err = actix_web::error::UrlParseError;
     fn from_param(s: &str) -> Result<Self, Self::Err> {
         Ok(CiString {
-            value: s.to_lowercase()
+            value: s.to_lowercase(),
         })
     }
 }
@@ -69,9 +69,7 @@ impl PartialEq<&str> for CiString {
     }
 }
 
-impl Eq for CiString {
-
-}
+impl Eq for CiString {}
 
 impl Hash for CiString {
     fn hash<H: Hasher>(&self, hasher: &mut H) {
@@ -102,7 +100,9 @@ impl Deref for CiString {
 impl FromStr for CiString {
     type Err = fmt::Error;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        Ok(CiString { value: s.to_lowercase() })
+        Ok(CiString {
+            value: s.to_lowercase(),
+        })
     }
 }
 
@@ -113,58 +113,59 @@ impl Into<String> for CiString {
 }
 
 impl From<String> for CiString {
-    fn from(value: String) ->  Self {
+    fn from(value: String) -> Self {
         CiString {
-            value: value.to_lowercase()
+            value: value.to_lowercase(),
         }
     }
 }
 
 impl From<&str> for CiString {
-    fn from(value: &str) ->  Self {
+    fn from(value: &str) -> Self {
         CiString {
-            value: value.to_lowercase()
+            value: value.to_lowercase(),
         }
     }
 }
 
 impl FromSql<Citext, Pg> for CiString {
-	fn from_sql(bytes: Option<&[u8]>) -> deserialize::Result<Self> {
-		use std::str;
+    fn from_sql(bytes: Option<&[u8]>) -> deserialize::Result<Self> {
+        use std::str;
         let string = str::from_utf8(not_none!(bytes))?;
-        Ok(CiString{ value: string.to_lowercase() })
-	}
+        Ok(CiString {
+            value: string.to_lowercase(),
+        })
+    }
 }
 
 impl ToSql<Citext, Pg> for CiString {
-	fn to_sql<W: Write>(&self, out: &mut Output<W, Pg>) -> serialize::Result {
+    fn to_sql<W: Write>(&self, out: &mut Output<W, Pg>) -> serialize::Result {
         out.write_all(self.value.as_bytes())
             .map(|_| IsNull::No)
             .map_err(|e| Box::new(e) as Box<Error + Send + Sync>)
-	}
+    }
 }
 
 impl FromSql<Citext, Pg> for String {
-	fn from_sql(bytes: Option<&[u8]>) -> deserialize::Result<Self> {
-		use std::str;
+    fn from_sql(bytes: Option<&[u8]>) -> deserialize::Result<Self> {
+        use std::str;
         let string = str::from_utf8(not_none!(bytes))?;
         Ok(string.to_lowercase())
-	}
+    }
 }
 
 impl ToSql<Citext, Pg> for String {
-	fn to_sql<W: Write>(&self, out: &mut Output<W, Pg>) -> serialize::Result {
+    fn to_sql<W: Write>(&self, out: &mut Output<W, Pg>) -> serialize::Result {
         out.write_all(self.to_lowercase().as_bytes())
             .map(|_| IsNull::No)
             .map_err(|e| Box::new(e) as Box<Error + Send + Sync>)
-	}
+    }
 }
 
 impl ToSql<Citext, Pg> for str {
-	fn to_sql<W: Write>(&self, out: &mut Output<W, Pg>) -> serialize::Result {
+    fn to_sql<W: Write>(&self, out: &mut Output<W, Pg>) -> serialize::Result {
         out.write_all(self.to_lowercase().as_bytes())
             .map(|_| IsNull::No)
             .map_err(|e| Box::new(e) as Box<Error + Send + Sync>)
-	}
+    }
 }
-

--- a/src/types.rs
+++ b/src/types.rs
@@ -103,7 +103,7 @@ impl Deref for CiString {
 }
 
 impl FromStr for CiString {
-    type Err = fmt::Error;
+    type Err = ();
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         Ok(Self::from(s))

--- a/src/types.rs
+++ b/src/types.rs
@@ -58,19 +58,19 @@ impl fmt::Display for CiString {
 
 impl PartialEq for CiString {
     fn eq(&self, other: &CiString) -> bool {
-        self.value == other.value
+        self.value.to_lowercase() == other.value.to_lowercase()
     }
 }
 
 impl PartialEq<String> for CiString {
     fn eq(&self, other: &String) -> bool {
-        self.value == other.to_lowercase()
+        self.value.to_lowercase() == other.to_lowercase()
     }
 }
 
 impl PartialEq<&str> for CiString {
     fn eq(&self, other: &&str) -> bool {
-        self.value == other.to_lowercase()
+        self.value.to_lowercase() == other.to_lowercase()
     }
 }
 
@@ -78,7 +78,7 @@ impl Eq for CiString {}
 
 impl Hash for CiString {
     fn hash<H: Hasher>(&self, hasher: &mut H) {
-        self.value.hash(hasher);
+        self.value.to_lowercase().hash(hasher);
     }
 }
 
@@ -117,17 +117,15 @@ impl Into<String> for CiString {
 }
 
 impl From<String> for CiString {
-    fn from(value: String) -> Self {
-        Self {
-            value: value.to_lowercase(),
-        }
+    fn from(value: String) ->  Self {
+        CiString { value }
     }
 }
 
 impl From<&str> for CiString {
-    fn from(value: &str) -> Self {
-        Self {
-            value: value.to_lowercase(),
+    fn from(value: &str) ->  Self {
+        CiString {
+            value: value.into(),
         }
     }
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -5,7 +5,6 @@ use diesel::serialize::{self, IsNull, Output, ToSql};
 use serde::{Deserialize, Deserializer, Serialize};
 use std::borrow::Borrow;
 use std::cmp::{Eq, PartialEq};
-use std::error::Error;
 use std::fmt;
 use std::hash::{Hash, Hasher};
 use std::io::prelude::*;
@@ -140,9 +139,8 @@ impl FromSql<Citext, Pg> for CiString {
 
 impl ToSql<Citext, Pg> for CiString {
     fn to_sql<W: Write>(&self, out: &mut Output<W, Pg>) -> serialize::Result {
-        out.write_all(self.value.as_bytes())
-            .map(|_| IsNull::No)
-            .map_err(|e| Box::new(e) as Box<Error + Send + Sync>)
+        Ok(out.write_all(self.value.as_bytes())
+            .map(|_| IsNull::No)?)
     }
 }
 
@@ -156,16 +154,14 @@ impl FromSql<Citext, Pg> for String {
 
 impl ToSql<Citext, Pg> for String {
     fn to_sql<W: Write>(&self, out: &mut Output<W, Pg>) -> serialize::Result {
-        out.write_all(self.to_lowercase().as_bytes())
-            .map(|_| IsNull::No)
-            .map_err(|e| Box::new(e) as Box<Error + Send + Sync>)
+        Ok(out.write_all(self.to_lowercase().as_bytes())
+            .map(|_| IsNull::No)?)
     }
 }
 
 impl ToSql<Citext, Pg> for str {
     fn to_sql<W: Write>(&self, out: &mut Output<W, Pg>) -> serialize::Result {
-        out.write_all(self.to_lowercase().as_bytes())
-            .map(|_| IsNull::No)
-            .map_err(|e| Box::new(e) as Box<Error + Send + Sync>)
+        Ok(out.write_all(self.to_lowercase().as_bytes())
+            .map(|_| IsNull::No)?)
     }
 }


### PR DESCRIPTION
Hello, This PR is a combination of #5 and #4.

I've changed the implementation so that we store only the original string (to avoid consuming double the memory), and lowering before comparison.

This more closely matches the behavior of CITEXT which also preserves case.